### PR TITLE
Use Linux commands to perform zip operation

### DIFF
--- a/create_zip.pl
+++ b/create_zip.pl
@@ -8,5 +8,5 @@ mkdir "binaries";
 
 chdir "builds";
 
-system("..\\tools\\7z.exe", "a", "-r" , "builds.zip", "*.exe", "*.pdb", "version.txt") eq 0 or die("failed creating builds.zip");
-system("move", "builds.zip", "..\\binaries");
+system("zip -rq builds.zip . -i *.exe *.pdb version.txt") && die("failed creating builds.zip");
+system("mv builds.zip ../binaries");


### PR DESCRIPTION
The "Completed" builder on Katana uses Linux machines instead of Windows; updating script to match.